### PR TITLE
Fix bindEvent arguments.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ type AllFontNames = keyof Omit<typeof Enum.Font, "GetEnumItems">;
 type IconEventName = keyof IconEvents;
 
 type InferSignalCallback<T> = T extends RBXScriptSignal<infer A> ? A : never;
-type InferEventCallback<T extends IconEventName> = InferSignalCallback<IconEvents[T]>;
+type InferEventCallback<T extends IconEventName> = (...args: [self: Icon, ...rest: Parameters<InferSignalCallback<IconEvents[T]>>]) => void;
 
 export type IconUID = string;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ type AllFontNames = keyof Omit<typeof Enum.Font, "GetEnumItems">;
 type IconEventName = keyof IconEvents;
 
 type InferSignalCallback<T> = T extends RBXScriptSignal<infer A> ? A : never;
-type InferEventCallback<T extends IconEventName> = (...args: [self: Icon, ...rest: Parameters<InferSignalCallback<IconEvents[T]>>]) => void;
+type InferEventCallback<T extends IconEventName> = (self: Icon, ...rest: Parameters<InferSignalCallback<IconEvents[T]>>) => void;
 
 export type IconUID = string;
 


### PR DESCRIPTION
Current typings for bindEvent (incorrect):
![image](https://github.com/user-attachments/assets/395b7351-7c19-46d2-8bdf-38d251dfece5)

Fixed typings (self/icon object is passed as first argument to bindEvent):
![image](https://github.com/user-attachments/assets/ec3a807c-ad76-4a3a-bf4a-d2fc9dddb11e)
